### PR TITLE
split_categorized: distinct layer shortnames even if replicated rule abels

### DIFF
--- a/split_categorized/split_categorized.py
+++ b/split_categorized/split_categorized.py
@@ -159,11 +159,12 @@ class SplitCategorizedLayersFilter(QgsServerFilter):
             )
 
             group = parent.insertGroup(pos, layer.name())
+            category_shortname = layer.serverProperties().shortName()
             for idx, category in enumerate(categories_list):
                 category_layer = layer.clone()
                 category_layer.serverProperties().setTitle(category.label())
                 category_layer.setName(category.label())
-                category_layer.serverProperties().setShortName(category.label())
+                category_layer.serverProperties().setShortName(f"{category_shortname}_{category.label()}")
                 category_layer.setCrs(layer.crs())
                 QgsExpressionContextUtils.setLayerVariable(category_layer, "convert_categorized_layer", "false")
                 QgsExpressionContextUtils.setLayerVariable(category_layer, "is_category_sublayer", "true")


### PR DESCRIPTION
Hey,

While using the plugin _split_categorized_ I ended up having an error with layers using the same rule label.

<img width="252" height="335" alt="same_labels" src="https://github.com/user-attachments/assets/6b0ae93e-d7bf-412a-8c1e-772ca8f59256" />

It would result in : 

```
Generating configuration...

INFO: Config destination: /srv/qwc_service/config-out/default
[...]
INFO: Downloaded WMS GetProjectSettings from http://qwc-qgis-server/ows/qwc_demo
CRITICAL: Duplicate layer name '0'! Please rename the duplicate occurrences.
CRITICAL: Duplicate layer name '1'! Please rename the duplicate occurrences.
INFO: Downloaded WFS GetCapabilities from http://qwc-qgis-server/ows/qwc_demo
[...]
INFO: Generating 'search' service config
CRITICAL: A critical error occurred while processing the configuration.
CRITICAL: The configuration files were not updated!
INFO: Generating 'adminGui' service permissions
[...]
INFO: Generating 'search' service permissions
CRITICAL: A critical error occurred while processing the configuration.
CRITICAL: The permission files were not updated!
```

The pull request prefixes the _shortName_ of the split layer with the _shortName_ of the parent layer, making them unique.

If the _shortName_ is empty then the error persists.

Cheers,

And thanks for qwc2 !